### PR TITLE
dupefindCntrl - Switch from (a)ttribute notation to (e)lement notation

### DIFF
--- a/ang/deduper/dupefindCntrl.html
+++ b/ang/deduper/dupefindCntrl.html
@@ -62,18 +62,18 @@
     <div class='panel panel-default' ng-show="deduperCntrl.showTiles">
       <div class="panel-heading">{{mergePair['srcName']}} vs {{mergePair['dstName']}}</div>
       <div class='panel-body' ng-show="deduperCntrl.showTiles">
-        <div class='col-md-4' contact-basic="{contact_id: mergePair['srcID'], display_name : mergePair['srcName'], 'contact_url' : contactURL}"></div>
+        <contact-basic class='col-md-4' options="{contact_id: mergePair['srcID'], display_name : mergePair['srcName'], 'contact_url' : contactURL}"></contact-basic>
 
         <div class='col-md-4'>
-          <div conflict-basic="{conflicts: mergePair['safe']['conflicts'], main_id : mergePair['srcID'], other_id : mergePair['dstID'], other_display_name : mergePair['dstName'],  main_display_name : mergePair['srcName'], fieldSpec : contactFields, equivalentNameSetting: equivalentNameSetting }">
-          </div>
+          <conflict-basic options="{conflicts: mergePair['safe']['conflicts'], main_id : mergePair['srcID'], other_id : mergePair['dstID'], other_display_name : mergePair['dstName'],  main_display_name : mergePair['srcName'], fieldSpec : contactFields, equivalentNameSetting: equivalentNameSetting }">
+          </conflict-basic>
           <button class="btn btn-success btn-block" id="retry-merge-{{mergePair['dstID']}}-{{mergePair['srcID']}}" ng-disabled=isRowMerging ng-click="retryMerge(mergePair['dstID'], mergePair['srcID'], mergePair, currentPage)">{{ ts('Safe Merge') }}</button>
           <button class="btn btn-primary btn-block" id="dedupe-exception-{{mergePair['dstID']}}-{{mergePair['srcID']}}" ng-disabled=isRowMerging ng-click="dedupeException(mergePair['dstID'], mergePair['srcID'], currentPage)">{{ ts('Mark non-dupe') }}</button>
           <button class="btn btn-primary btn-block" id="delay-pair-{{mergePair['dstID']}}-{{mergePair['srcID']}}" ng-disabled=isRowMerging ng-click="delayPair(mergePair['dstID'], mergePair['srcID'], currentPage)">{{ ts('Ask me Later') }}</button>
           <button class="btn btn-danger btn-block" id="force-merge-{{mergePair['dstID']}}-{{mergePair['srcID']}}" ng-show="mergePair['safe']['conflicts']" ng-disabled=isRowMerging ng-click="forceMerge(mergePair['dstID'], mergePair['srcID'], currentPage)">{{ ts('Force Merge') }}</button>
           <div><a target="_blank" class="btn btn-link btn-block" href="{{mergeURL}}&cid={{mergePair['dstID']}}&oid={{mergePair['srcID']}}">{{ ts('Manual Merge') }}</a></div>
         </div>
-        <div class='col-md-4'  contact-basic="{contact_id: mergePair['dstID'], display_name : mergePair['dstName'], 'contact_url' : contactURL}"></div>
+        <contact-basic class='col-md-4' options="{contact_id: mergePair['dstID'], display_name : mergePair['dstName'], 'contact_url' : contactURL}"></contact-basic>
      </div>
     </div>
 


### PR DESCRIPTION
This updates to match the breaking change proposed for 5.35 in https://github.com/civicrm/civicrm-core/pull/19438

```html
<!-- Old attribute notation -->
<div MY-SUBFORM="..."></div>

<!-- New element notation -->
<MY-SUBFORM options="..."></MY-SUBFORM>
```

(Note: This is a formulaic patch and I haven't `r-run`.)