### PR TITLE
Add 'flip' as a contact task to search kit

### DIFF
--- a/ang/dedupeSearchTasks.ang.php
+++ b/ang/dedupeSearchTasks.ang.php
@@ -1,0 +1,16 @@
+<?php
+// This file declares an Angular module which can be autoloaded
+// in CiviCRM. See also:
+// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
+
+return [
+  'js' => [
+    'ang/dedupeSearchTasks.js',
+    'ang/dedupeSearchTasks/*.js',
+    'ang/dedupeSearchTasks/*/*.js',
+  ],
+  'partials' => [
+    'ang/dedupeSearchTasks',
+  ],
+  'requires' => ['api4'],
+];

--- a/ang/dedupeSearchTasks.js
+++ b/ang/dedupeSearchTasks.js
@@ -1,0 +1,5 @@
+(function(angular, $, _) {
+  // Declare a list of dependencies.
+  angular.module('dedupeSearchTasks', CRM.angRequires('dedupeSearchTasks'));
+
+})(angular, CRM.$, CRM._);

--- a/ang/dedupeSearchTasks/dedupeSearchTaskFlip.ctrl.js
+++ b/ang/dedupeSearchTasks/dedupeSearchTaskFlip.ctrl.js
@@ -1,0 +1,34 @@
+(function(angular, $, _) {
+  "use strict";
+
+  angular.module('dedupeSearchTasks').controller('dedupeSearchTaskFlip', function($scope, dialogService) {
+    var ts = $scope.ts = CRM.ts('deduper'),
+      model = $scope.model,
+      ctrl = this;
+
+    this.entityTitle = model.ids.length === 1 ? model.entityInfo.title : model.entityInfo.title_plural;
+
+    this.cancel = function() {
+      dialogService.cancel('crmSearchTask');
+    };
+
+    this.flip = function() {
+      $('.ui-dialog-titlebar button').hide();
+      ctrl.run = {
+        select: ['first_name', 'last_name'],
+        chain: {update: ['Contact', 'update', {where: [['id', '=', '$id']], values: {'first_name': '$last_name', 'last_name': '$first_name'}}]}
+      };
+    };
+
+    this.onSuccess = function() {
+      CRM.alert(ts('Successfully updated %1 %2.', {1: model.ids.length, 2: ctrl.entityTitle}), ts('Names flipped'), 'success');
+      dialogService.close('crmSearchTask');
+    };
+
+    this.onError = function() {
+      CRM.alert(ts('An error occurred while attempting to update %1 %2.', {1: model.ids.length, 2: ctrl.entityTitle}), ts('Error'), 'error');
+      dialogService.close('crmSearchTask');
+    };
+
+  });
+})(angular, CRM.$, CRM._);

--- a/ang/dedupeSearchTasks/dedupeSearchTaskFlip.html
+++ b/ang/dedupeSearchTasks/dedupeSearchTaskFlip.html
@@ -1,0 +1,21 @@
+<div id="bootstrap-theme">
+  <form ng-controller="dedupeSearchTaskFlip as $ctrl">
+    <p><strong>{{:: ts('Flip the first/last names of %1 %2?', {1: model.ids.length, 2: $ctrl.entityTitle}) }}</strong></p>
+    <hr />
+    <div ng-if="$ctrl.run" class="crm-search-task-progress">
+      <h5>{{:: ts('Updating %1 %2...', {1: model.ids.length, 2: $ctrl.entityTitle}) }}</h5>
+      <crm-search-batch-runner entity="model.entity" action="Get" params="$ctrl.run" ids="model.ids" success="$ctrl.onSuccess()" error="$ctrl.onError()" ></crm-search-batch-runner>
+    </div>
+    <hr />
+    <div class="buttons text-right">
+      <button type="button" ng-click="$ctrl.cancel()" class="btn btn-danger" ng-hide="$ctrl.run">
+        <i class="crm-i fa-times"></i>
+        {{:: ts('Cancel') }}
+      </button>
+      <button ng-click="$ctrl.flip()" class="btn btn-primary" ng-disabled="$ctrl.run">
+        <i class="crm-i fa-{{ $ctrl.run ? 'spin fa-spinner' : 'random' }}"></i>
+        {{:: ts('Flip %1', {1: $ctrl.entityTitle}) }}
+      </button>
+    </div>
+  </form>
+</div>

--- a/ang/deduper.js
+++ b/ang/deduper.js
@@ -1,6 +1,6 @@
 (function(angular, $, _) {
   // Declare a list of dependencies.
-  var app = angular.module('deduper', CRM.angRequires('deduper', 'contactBasic', 'conflictBasic'));
+  var app = angular.module('deduper', CRM.angRequires('deduper'));
   app.run(function(editableOptions) {
     editableOptions.theme = 'bs3';
   });

--- a/deduper.php
+++ b/deduper.php
@@ -115,10 +115,6 @@ function deduper_civicrm_caseTypes(&$caseTypes) {
 /**
  * Implements hook_civicrm_angularModules().
  *
- * Generate a list of Angular modules.
- *
- * Note: This hook only runs in CiviCRM 4.5+. It may
- * use features only available in v4.6+.
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
@@ -133,7 +129,20 @@ function deduper_civicrm_angularModules(&$angularModules) {
     'ext' => 'deduper',
     'js' => ['bower_components/angularUtils-pagination/dirPagination.js'],
   ];
+}
 
+/**
+ * Implements hook_civicrm_searchKitTasks().
+ *
+ * @param array[] $tasks
+ */
+function deduper_civicrm_searchKitTasks(&$tasks) {
+  $tasks['Contact']['flip'] = [
+    'module' => 'dedupeSearchTasks',
+    'title' => E::ts('Flip first/last name'),
+    'icon' => 'fa-random',
+    'uiDialog' => ['templateUrl' => '~/dedupeSearchTasks/dedupeSearchTaskFlip.html'],
+  ];
 }
 
 /**


### PR DESCRIPTION
This action flips first & last names.

Note: This adds it as an action on Contact searches. With a little tweak it could be added to one of the entities in this extension which are contact-like.

Depends on https://github.com/civicrm/civicrm-core/pull/20307

![image](https://user-images.githubusercontent.com/2874912/118297778-99a47a80-b4ac-11eb-8108-ac1511afd153.png)
