### PR TITLE
Remove deprecated `includeCustom` param from `getFields` api call.

### DIFF
--- a/CRM/Deduper/BAO/MergeConflict.php
+++ b/CRM/Deduper/BAO/MergeConflict.php
@@ -123,11 +123,8 @@ class CRM_Deduper_BAO_MergeConflict extends CRM_Deduper_DAO_MergeConflict {
    * @throws \API_Exception
    */
   public static function getLocationTypes() : array {
-    return Email::getFields()
-      ->setCheckPermissions(FALSE)
-      ->setIncludeCustom(FALSE)
+    return Email::getFields(FALSE)
       ->setLoadOptions(TRUE)
-      ->addSelect('options')
       ->addWhere('name', '=', 'location_type_id')
       ->execute()->first()['options'];
   }


### PR DESCRIPTION
I'm deprecating this api param, but it wasn't needed in this case anyway, because the api is already smart enough to not load custom fields if your `where` clause specifies the names of only core fields.