### PR TITLE
uniqid fix

### DIFF
--- a/deduper.php
+++ b/deduper.php
@@ -315,7 +315,7 @@ function deduper_civicrm_merge($type, &$refs, $mainId, $otherId, $tables) {
       // Randomise log connection id. This ensures reverts can be done without reverting the whole batch if logging is enabled.
       CRM_Core_DAO::executeQuery('SET @uniqueID = %1', array(
         1 => array(
-          uniqid('rand', FALSE) . CRM_Utils_String::createRandom(4, CRM_Utils_String::ALPHANUMERIC),
+          uniqid() . CRM_Utils_String::createRandom(4, CRM_Utils_String::ALPHANUMERIC),
           'String',
         ),
       ));


### PR DESCRIPTION
I was getting errors that my `log_conn_id` was too long, which I thought was impressive given that the value controlling `@uniqueID` is cached.  I temporarily modified my column sizes so I could see that `rand` was being appended to what looked like a normal `uniqid()` result.

I finally found this code. I'm not sure what the intent is, but the first value passed to `uniqid()` is used as a prefix.  Removing this fixed the issue. 