### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Deduper/BAO/ContactNamePair.php
+++ b/CRM/Deduper/BAO/ContactNamePair.php
@@ -16,7 +16,7 @@ class CRM_Deduper_BAO_ContactNamePair extends CRM_Deduper_DAO_ContactNamePair {
     $entityName = 'ContactNamePair';
     $hook = empty($params['id']) ? 'create' : 'edit';
 
-    CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
+    CRM_Utils_Hook::pre($hook, $entityName, $params['id'] ?? NULL, $params);
     /* @var self $instance */
     $instance = new $className();
     if (!isset($params['id'])) {

--- a/CRM/Deduper/BAO/MergeConflict.php
+++ b/CRM/Deduper/BAO/MergeConflict.php
@@ -30,7 +30,7 @@ class CRM_Deduper_BAO_MergeConflict extends CRM_Deduper_DAO_MergeConflict {
           || ($fieldName === 'on_hold' && !Civi::settings()->get('civimail_multiple_bulk_emails'))
         )
       ) {
-        $prefix = CRM_Utils_Array::value('entity', $fieldSpec) === 'Email' ? E::ts('Email::') : '';
+        $prefix = ($fieldSpec['entity'] ?? NULL) === 'Email' ? E::ts('Email::') : '';
         $booleanFields[$fieldSpec['name']] = $prefix . $fieldSpec['title'];
       }
     }

--- a/api/v3/Merge/Getcount.php
+++ b/api/v3/Merge/Getcount.php
@@ -30,7 +30,7 @@ function _civicrm_api3_merge_getcount_spec(&$spec) {
  * @throws \CRM_Core_Exception
  */
 function civicrm_api3_merge_getcount($params) {
-  $cacheKeyString = CRM_Dedupe_Merger::getMergeCacheKeyString($params['rule_group_id'], CRM_Utils_Array::value('group_id', $params), $params['criteria'], CRM_Utils_Array::value('check_permissions', $params), $params['search_limit']);
+  $cacheKeyString = CRM_Dedupe_Merger::getMergeCacheKeyString($params['rule_group_id'], $params['group_id'] ?? NULL, $params['criteria'], $params['check_permissions'] ?? NULL, $params['search_limit']);
   // @todo - pretty sure these joins are no longer required as we remove from the cache once they have
   // been marked duplicates now.
   return CRM_Core_DAO::singleValueQuery("

--- a/api/v3/Merge/MarkDuplicateException.php
+++ b/api/v3/Merge/MarkDuplicateException.php
@@ -33,7 +33,7 @@ function _civicrm_api3_merge_mark_duplicate_exceptionspec(&$spec) {
  */
 function civicrm_api3_merge_mark_duplicate_exception($params) {
   // @todo be careful if we later enable refillCache since there is no limit...
-  $pairs = CRM_Dedupe_Merger::getDuplicatePairs($params['rule_group_id'], NULL, FALSE, 0, FALSE, TRUE, $params['criteria'], CRM_Utils_Array::value('check_permissions', $params), $params['search_limit']);
+  $pairs = CRM_Dedupe_Merger::getDuplicatePairs($params['rule_group_id'], NULL, FALSE, 0, FALSE, TRUE, $params['criteria'], $params['check_permissions'] ?? NULL, $params['search_limit']);
   foreach ($pairs as $pair) {
     civicrm_api3('Exception', 'create', ['contact_id1' => $pair['dstID'], 'contact_id2' => $pair['srcID']]);
     CRM_Core_DAO::executeQuery('


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.