### PR TITLE
Clean up emails of same setting kept-type that are the same string

### DIFF
--- a/Civi/Api4/CleanBase.php
+++ b/Civi/Api4/CleanBase.php
@@ -137,10 +137,8 @@ abstract class CleanBase extends AbstractAction {
         // Treat it as 'one of the other existing types' so re-homing kicks in.
         $entity['location_type_id'] = $locationTypeForUnassigned;
       }
-      if ($entity['is_primary'] || !in_array($entity['location_type_id'], $this->getLocationTypesToKeep(), TRUE)) {
-        $return[$entity['location_type_id'] . ($entity['phone_type_id'] ?? '')][$id] = $entity;
-        $locationTypeForUnassigned = $entity['location_type_id'];
-      }
+      $return[$entity['location_type_id'] . ($entity['phone_type_id'] ?? '')][$id] = $entity;
+      $locationTypeForUnassigned = $entity['location_type_id'];
     }
     return $return;
   }
@@ -186,7 +184,7 @@ abstract class CleanBase extends AbstractAction {
                 }
                 $this->idsToDelete[] = $entity['id'];
               }
-              elseif ($this->hasSalientData($entity)) {
+              elseif ($this->hasSalientData($entity) && !in_array($entity['location_type_id'], $this->getLocationTypesToKeep(), TRUE)) {
                 $this->idsToRelocate[$contactID][$entityKey] = $entity;
               }
             }
@@ -195,21 +193,24 @@ abstract class CleanBase extends AbstractAction {
             // We have altered keeper (augmented it with detail from another address) so we save the update.
             $this->update($keeper['id'], $keeper);
           }
+          if (!in_array($keeper['location_type_id'], $this->getLocationTypesToKeep(), TRUE)) {
+            $this->setEntityToBeDeletedIfEquivalentAlreadyBeingKept($contactID, $keeper);
+          }
         }
         else {
-          foreach($entities as $entity) {
+          $singleEntity = reset($entities);
+          if (!$singleEntity['is_primary'] && in_array($singleEntity['location_type_id'], $this->getLocationTypesToKeep(), TRUE)) {
+            continue;
+          }
+          foreach ($entities as $entity) {
             if (!$this->hasSalientData($entity)) {
               // Deleting empty entities pre-merge prevents them overwriting good entities.
               $this->idsToDelete[] = $entity['id'];
             }
             else {
-              $keeper = $entity;
+              $this->setEntityToBeDeletedIfEquivalentAlreadyBeingKept($contactID, $entity);
             }
           }
-        }
-
-        if (!empty($keeper)) {
-          $this->setEntityToBeDeletedIfEquivalentAlreadyBeingKept($contactID, $keeper);
         }
       }
     }

--- a/tests/phpunit/CRM/Deduper/CleanTest.php
+++ b/tests/phpunit/CRM/Deduper/CleanTest.php
@@ -178,47 +178,90 @@ class CleanTest extends DedupeBaseTestClass {
   }
 
   /**
-   * Test that duplicate emails of location types we want to keep are kept,
+   * Test that entities of location types we want to keep are kept,
    * while duplicates of other location types are removed.
    *
+   * @dataProvider getLocationEntityData
    * @throws \CRM_Core_Exception
    */
-  public function testCleanDuplicateEmailHandlingKeepingLocationTypes(): void {
-    $this->entity = 'Email';
-    $this->setSetting('deduper_clean_location_types_to_keep_email', ['exclude']);
-    unset(Civi::$statics[\Civi\Api4\Action\Email\Clean::class]);
-    $excludeTypeID = LocationType::save(FALSE)
-      ->setRecords([['name' => 'exclude', 'display_name' => 'Exclude', 'is_active' => TRUE]])
-      ->setMatch(['name'])
-      ->execute()->first()['id'];
+  public function testCleanDuplicateWithKeptLocationTypes(string $entity, array $values): void {
+    $excludeTypeID = $this->setUpWithKeptLocationType($entity);
+    $contactID = $this->ids['contact']['Ponyo'];
 
-    $this->ids['contact']['Ponyo'] = $this->callAPISuccess('Contact', 'create', ['contact_type' => 'Individual', 'first_name' => 'Ponyo'])['id'];
-
-    $this->createEntity([
-      'email' => 'ponyo@example.com',
-      'location_type_id' => $this->locationTypes['Home'],
-      'contact_id' => $this->ids['contact']['Ponyo'],
-      'is_primary' => TRUE,
-    ]);
+    $this->createEntity(array_merge($values, ['location_type_id' => $this->locationTypes['Home'], 'contact_id' => $contactID, 'is_primary' => TRUE]));
     // Exclude type duplicate — should be kept.
-    $this->createEntity([
-      'email' => 'ponyo@example.com',
-      'location_type_id' => $excludeTypeID,
-      'contact_id' => $this->ids['contact']['Ponyo'],
-    ]);
+    $this->createEntity(array_merge($values, ['location_type_id' => $excludeTypeID, 'contact_id' => $contactID]));
     // Main duplicate — should be removed.
-    $this->createEntity([
-      'email' => 'ponyo@example.com',
-      'location_type_id' => $this->locationTypes['Main'],
-      'contact_id' => $this->ids['contact']['Ponyo'],
-    ]);
+    $this->createEntity(array_merge($values, ['location_type_id' => $this->locationTypes['Main'], 'contact_id' => $contactID]));
 
-    $this->doClean($this->ids['contact']['Ponyo']);
+    $this->doClean($contactID);
 
     // Home (primary) + exclude are kept, Main is removed.
-    $this->checkEntities($this->ids['contact']['Ponyo'], [
-      ['email' => 'ponyo@example.com', 'location_type_id' => $this->locationTypes['Home'], 'is_primary' => TRUE],
-      ['email' => 'ponyo@example.com', 'location_type_id' => $excludeTypeID, 'is_primary' => FALSE],
+    $this->checkEntities($contactID, [
+      array_merge($values, ['location_type_id' => $this->locationTypes['Home'], 'is_primary' => TRUE]),
+      array_merge($values, ['location_type_id' => $excludeTypeID, 'is_primary' => FALSE]),
+    ]);
+  }
+
+  /**
+   * Two identical entities of the same kept location type — duplicate should be removed.
+   *
+   * @dataProvider getLocationEntityData
+   * @throws \CRM_Core_Exception
+   */
+  public function testCleanDuplicateSameValueSameKeptLocationType(string $entity, array $values): void {
+    $excludeTypeID = $this->setUpWithKeptLocationType($entity);
+    $contactID = $this->ids['contact']['Ponyo'];
+
+    $this->createEntity(array_merge($values, ['location_type_id' => $excludeTypeID, 'contact_id' => $contactID, 'is_primary' => TRUE]));
+    $this->createEntity(array_merge($values, ['location_type_id' => $excludeTypeID, 'contact_id' => $contactID]));
+
+    $this->doClean($contactID);
+
+    $this->checkEntities($contactID, [
+      array_merge($values, ['location_type_id' => $excludeTypeID, 'is_primary' => TRUE]),
+    ]);
+  }
+
+  /**
+   * Two different entities of the same kept location type — both should be left alone.
+   *
+   * @dataProvider getLocationEntityData
+   * @throws \CRM_Core_Exception
+   */
+  public function testCleanDuplicateDifferentValueSameKeptLocationType(string $entity, array $values, array $secondaryValues): void {
+    $excludeTypeID = $this->setUpWithKeptLocationType($entity);
+    $contactID = $this->ids['contact']['Ponyo'];
+
+    $this->createEntity(array_merge($values, ['location_type_id' => $excludeTypeID, 'contact_id' => $contactID, 'is_primary' => TRUE]));
+    $this->createEntity(array_merge($secondaryValues, ['location_type_id' => $excludeTypeID, 'contact_id' => $contactID]));
+
+    $this->doClean($contactID);
+
+    $this->checkEntities($contactID, [
+      array_merge($values, ['location_type_id' => $excludeTypeID, 'is_primary' => TRUE]),
+      array_merge($secondaryValues, ['location_type_id' => $excludeTypeID, 'is_primary' => FALSE]),
+    ]);
+  }
+
+  /**
+   * A kept-type entity matching the primary of a different location type should not be deleted.
+   *
+   * @dataProvider getLocationEntityData
+   * @throws \CRM_Core_Exception
+   */
+  public function testCleanKeptLocationTypeNotDeletedWhenMatchesPrimary(string $entity, array $values): void {
+    $excludeTypeID = $this->setUpWithKeptLocationType($entity);
+    $contactID = $this->ids['contact']['Ponyo'];
+
+    $this->createEntity(array_merge($values, ['location_type_id' => $this->locationTypes['Home'], 'contact_id' => $contactID, 'is_primary' => TRUE]));
+    $this->createEntity(array_merge($values, ['location_type_id' => $excludeTypeID, 'contact_id' => $contactID]));
+
+    $this->doClean($contactID);
+
+    $this->checkEntities($contactID, [
+      array_merge($values, ['location_type_id' => $this->locationTypes['Home'], 'is_primary' => TRUE]),
+      array_merge($values, ['location_type_id' => $excludeTypeID, 'is_primary' => FALSE]),
     ]);
   }
 
@@ -230,9 +273,32 @@ class CleanTest extends DedupeBaseTestClass {
   public function getLocationEntityData(): array {
     return [
       ['Address', ['street_address' => '10 Downing Street'], ['street_address' => '10 Sesame Street']],
-      ['Phone', ['phone' => '555-666', 'phone_type_id' => 1], ['phone' => '666-777']],
+      ['Phone', ['phone' => '555-666', 'phone_type_id' => 1], ['phone' => '666-777', 'phone_type_id' => 1]],
       ['Email', ['email' => 'ponyo@example.com'], ['email' => 'totoro@example.com']],
     ];
+  }
+
+  /**
+   * Set up the 'exclude' kept-location-type and a Ponyo contact.
+   *
+   * @return int The ID of the 'exclude' location type.
+   * @throws \CRM_Core_Exception
+   */
+  protected function setUpWithKeptLocationType(string $entity): int {
+    $this->entity = $entity;
+    $this->setSetting('deduper_clean_location_types_to_keep_' . strtolower($entity), ['exclude']);
+    $cleanClasses = [
+      'Email'   => \Civi\Api4\Action\Email\Clean::class,
+      'Phone'   => \Civi\Api4\Action\Phone\Clean::class,
+      'Address' => \Civi\Api4\Action\Address\Clean::class,
+    ];
+    unset(Civi::$statics[$cleanClasses[$entity]]);
+    $excludeTypeID = LocationType::save(FALSE)
+      ->setRecords([['name' => 'exclude', 'display_name' => 'Exclude', 'is_active' => TRUE]])
+      ->setMatch(['name'])
+      ->execute()->first()['id'];
+    $this->ids['contact']['Ponyo'] = $this->callAPISuccess('Contact', 'create', ['contact_type' => 'Individual', 'first_name' => 'Ponyo'])['id'];
+    return $excludeTypeID;
   }
 
   /**


### PR DESCRIPTION
My last patch was too broad, preventing this. Added tests and broadened tests from the last patch to cover addresses and phones too.